### PR TITLE
Feature:  Added the add_translate function to transform/translate by xyz an existing part

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -698,7 +698,7 @@ to "copy" the part (same as "Copy Part" checkbox in GUI)
 # get the part from part studio with the name of "triangle"
 part = partstudio.parts.get('triangle')
 
-# Create a copy of the part and move it 10,80,30 in the x,y,z directions
+# create a copy of the part and move it 10,80,30 in the x,y,z directions
 partstudio.add_translate(part,x=10,y=80,z=30,copy=True)
 ```
 

--- a/guide.md
+++ b/guide.md
@@ -53,7 +53,7 @@ Depending on the circumstance, you can move sketches to other planes using offse
 
 After you have created a sketch, perform some 3D operation on it. Currently, OnPy only supports extrusions and lofts, but these are powerful in their own right. If your sketch has multiple regions, you can query them based on their properties. Queries will be discussed later.
 
-After you have created a 3D object, also known as a Part, you can perform additional queries and operations on it. You can reference part faces, edges, vertices, etc. in order to define additional sketches.
+After you have created a 3D object, also known as a Part, you can perform additional queries and operations on it, such as translate (Transform/Translate by XYZ). You can reference part faces, edges, vertices, etc. in order to define additional sketches.
 
 ## Defining a Sketch
 
@@ -487,6 +487,30 @@ def add_extrude(
     """
     ...
 
+def add_translate(
+    self,
+    part: Part,
+    name: str = "New Translate",
+    x: float = 0,
+    y: float = 0,
+    z: float = 0,
+    copy: bool = False,
+) -> Translate:
+    """Add a new transform of type translate_xyz feature to the partstudio.
+
+    Args:
+        part: The part to be translated
+        name: The name of the extrusion feature
+        x: The distance to move in x direction
+        y: The distance to move in y direction
+        z: The distance to move in z direction
+        copy: Bool to indicate part should be copied
+
+    Returns:
+        An Translated object
+
+    """
+
 def add_loft(
     self,
     start: FaceEntityConvertible,
@@ -662,6 +686,22 @@ often leads to feature errors.
 Lofts take two parameters, start and end, with a third, optional name parameter.
 The example above in the "Offset Plane" section exemplifies how to use lofts.
 
+### Translate
+
+A translate operates on an existing part (an object in part studio).  This is the "Transform" function of type
+"Translate by XYZ" present in the GUI.
+
+This will esentially move a part by the specified x,y,z units (uses default units of the document), with an option
+to "copy" the part (same as "Copy Part" checkbox in GUI)
+
+```python
+# get the part from part studio with the name of "triangle"
+part = partstudio.parts.get('triangle')
+
+# Create a copy of the part and move it 10,80,30 in the x,y,z directions
+partstudio.add_translate(part,x=10,y=80,z=30,copy=True)
+```
+
 ## Parts
 
 Sometimes, features will result in a new part. For instance, when you extrude a sketch for the first time, a new part is made.
@@ -685,6 +725,8 @@ with parts. If you want to get an idea of what parts are available, you can run:
 
 This will display the parts available. Then, you can access the parts by index (`partstudio.parts[0]`),
 name (`partstudio.parts.get("Housing")`), or id (`partstudio.parts.get_id("JKD")`)
+
+You can use the partudio `add_translate` function to move or copy the part.
 
 If you want to manually iterate over a list of parts, you can call `partstudio.list_parts()`
 and this will return a plain list of Part objects.

--- a/guide.md
+++ b/guide.md
@@ -507,7 +507,7 @@ def add_translate(
         copy: Bool to indicate part should be copied
 
     Returns:
-        An Translated object
+        A Translated object
 
     """
 

--- a/guide.md
+++ b/guide.md
@@ -726,8 +726,6 @@ with parts. If you want to get an idea of what parts are available, you can run:
 This will display the parts available. Then, you can access the parts by index (`partstudio.parts[0]`),
 name (`partstudio.parts.get("Housing")`), or id (`partstudio.parts.get_id("JKD")`)
 
-You can use the partudio `add_translate` function to move or copy the part.
-
 If you want to manually iterate over a list of parts, you can call `partstudio.list_parts()`
 and this will return a plain list of Part objects.
 

--- a/src/onpy/api/schema.py
+++ b/src/onpy/api/schema.py
@@ -224,7 +224,7 @@ class Sketch(Feature):
     entities: list[dict] | None  # dict is FeatureEntity
 
 class Extrude(Feature):
-    """Represents an Translate Feature."""
+    """Represents an Extrude Feature."""
 
     btType: str = "BTMFeature-134"
     featureType: str = "extrude"

--- a/src/onpy/api/schema.py
+++ b/src/onpy/api/schema.py
@@ -223,13 +223,17 @@ class Sketch(Feature):
     constraints: list[dict] | None = []
     entities: list[dict] | None  # dict is FeatureEntity
 
-
 class Extrude(Feature):
-    """Represents an Extrude Feature."""
+    """Represents an Translate Feature."""
 
     btType: str = "BTMFeature-134"
     featureType: str = "extrude"
 
+class Translate(Feature):
+    """Represents an Translate Feature."""
+
+    btType: str = "BTMFeature-134"
+    featureType: str = "transform"
 
 class Plane(Feature):
     """Represents a Plane Feature."""

--- a/src/onpy/api/schema.py
+++ b/src/onpy/api/schema.py
@@ -223,17 +223,20 @@ class Sketch(Feature):
     constraints: list[dict] | None = []
     entities: list[dict] | None  # dict is FeatureEntity
 
+
 class Extrude(Feature):
     """Represents an Extrude Feature."""
 
     btType: str = "BTMFeature-134"
     featureType: str = "extrude"
 
+
 class Translate(Feature):
     """Represents an Translate Feature."""
 
     btType: str = "BTMFeature-134"
     featureType: str = "transform"
+
 
 class Plane(Feature):
     """Represents a Plane Feature."""

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -120,6 +120,36 @@ class PartStudio(Element):
             subtract_from=subtract_from,
         )
 
+    def add_translate(
+        self,
+        name: str = "New Extrude",
+        move_x: float,
+        move_y: float,
+        move_z: float,
+        copy_part: bool,
+    ) -> Translate:
+        """Add a new transform of type translate_xyz feature to the partstudio.
+
+        Args:
+            name: The name of the extrusion feature
+            move_x: The distance to move in x direction
+            move_y: The distance to move in y direction
+            move_z: The distance to move in z direction
+            copy_part: Bool to indicate part should be copied
+
+        Returns:
+            An Translated object
+
+        """
+        return Translate(
+            partstudio = self,
+            name = name,
+            move_x = move_x,
+            move_y = move_y,
+            move_z = move_z,
+            copy_part = copy_part,
+        )
+
     def add_loft(
         self,
         start: FaceEntityConvertible,

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -124,20 +124,20 @@ class PartStudio(Element):
         self,
         part: Part,
         name: str = "New Translate",
-        move_x: float = 0,
-        move_y: float = 0,
-        move_z: float = 0,
-        copy_part: bool = False,
+        x: float = 0,
+        y: float = 0,
+        z: float = 0,
+        copy: bool = False,
     ) -> Translate:
         """Add a new transform of type translate_xyz feature to the partstudio.
 
         Args:
             part: The part to be translated
             name: The name of the extrusion feature
-            move_x: The distance to move in x direction
-            move_y: The distance to move in y direction
-            move_z: The distance to move in z direction
-            copy_part: Bool to indicate part should be copied
+            x: The distance to move in x direction
+            y: The distance to move in y direction
+            z: The distance to move in z direction
+            copy: Bool to indicate part should be copied
 
         Returns:
             An Translated object
@@ -147,10 +147,10 @@ class PartStudio(Element):
             partstudio = self,
             part = part,
             name = name,
-            move_x = move_x,
-            move_y = move_y,
-            move_z = move_z,
-            copy_part = copy_part,
+            x = x,
+            y = y,
+            z = z,
+            copy = copy,
         )
 
     def add_loft(

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -133,7 +133,7 @@ class PartStudio(Element):
 
         Args:
             part: The part to be translated
-            name: The name of the extrusion feature
+            name: The name of the translation feature
             x: The distance to move in x direction
             y: The distance to move in y direction
             z: The distance to move in z direction

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -122,7 +122,7 @@ class PartStudio(Element):
 
     def add_translate(
         self,
-        part_id: str,
+        part: Part,
         name: str = "New Translate",
         move_x: float = 0,
         move_y: float = 0,
@@ -132,7 +132,7 @@ class PartStudio(Element):
         """Add a new transform of type translate_xyz feature to the partstudio.
 
         Args:
-            part_id: The id of the part to be translated
+            part: The part to be translated
             name: The name of the extrusion feature
             move_x: The distance to move in x direction
             move_y: The distance to move in y direction
@@ -145,7 +145,7 @@ class PartStudio(Element):
         """
         return Translate(
             partstudio = self,
-            part_id = part_id,
+            part = part,
             name = name,
             move_x = move_x,
             move_y = move_y,

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -15,7 +15,7 @@ from onpy.api import schema
 from onpy.api.versioning import WorkspaceWVM
 from onpy.elements.base import Element
 from onpy.entities.protocols import BodyEntityConvertible, FaceEntityConvertible
-from onpy.features import Extrude, Translate, Loft, OffsetPlane, Plane, Sketch
+from onpy.features import Extrude, Loft, OffsetPlane, Plane, Sketch, Translate
 from onpy.features.base import Feature, FeatureList
 from onpy.features.planes import DefaultPlane, DefaultPlaneOrientation
 from onpy.part import Part, PartList
@@ -127,6 +127,7 @@ class PartStudio(Element):
         x: float = 0,
         y: float = 0,
         z: float = 0,
+        *,
         copy: bool = False,
     ) -> Translate:
         """Add a new transform of type translate_xyz feature to the partstudio.
@@ -144,13 +145,13 @@ class PartStudio(Element):
 
         """
         return Translate(
-            partstudio = self,
-            part = part,
-            name = name,
-            x = x,
-            y = y,
-            z = z,
-            copy = copy,
+            partstudio=self,
+            part=part,
+            name=name,
+            x=x,
+            y=y,
+            z=z,
+            copy=copy,
         )
 
     def add_loft(

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -15,7 +15,7 @@ from onpy.api import schema
 from onpy.api.versioning import WorkspaceWVM
 from onpy.elements.base import Element
 from onpy.entities.protocols import BodyEntityConvertible, FaceEntityConvertible
-from onpy.features import Extrude, Loft, OffsetPlane, Plane, Sketch
+from onpy.features import Extrude, Translate, Loft, OffsetPlane, Plane, Sketch
 from onpy.features.base import Feature, FeatureList
 from onpy.features.planes import DefaultPlane, DefaultPlaneOrientation
 from onpy.part import Part, PartList
@@ -123,10 +123,10 @@ class PartStudio(Element):
     def add_translate(
         self,
         name: str = "New Extrude",
-        move_x: float,
-        move_y: float,
-        move_z: float,
-        copy_part: bool,
+        move_x: float = 0,
+        move_y: float = 0,
+        move_z: float = 0,
+        copy_part: bool = False,
     ) -> Translate:
         """Add a new transform of type translate_xyz feature to the partstudio.
 

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -137,7 +137,7 @@ class PartStudio(Element):
             x: The distance to move in x direction
             y: The distance to move in y direction
             z: The distance to move in z direction
-            copy: Bool to indicate part should be copied
+            copy: Bool to indicate if part should be copied
 
         Returns:
             An Translated object

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -123,7 +123,7 @@ class PartStudio(Element):
     def add_translate(
         self,
         part_id: str,
-        name: str = "New Extrude",
+        name: str = "New Translate",
         move_x: float = 0,
         move_y: float = 0,
         move_z: float = 0,

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -122,6 +122,7 @@ class PartStudio(Element):
 
     def add_translate(
         self,
+        part_id: str,
         name: str = "New Extrude",
         move_x: float = 0,
         move_y: float = 0,
@@ -131,6 +132,7 @@ class PartStudio(Element):
         """Add a new transform of type translate_xyz feature to the partstudio.
 
         Args:
+            part_id: The id of the part to be translated
             name: The name of the extrusion feature
             move_x: The distance to move in x direction
             move_y: The distance to move in y direction
@@ -143,6 +145,7 @@ class PartStudio(Element):
         """
         return Translate(
             partstudio = self,
+            part_id = part_id,
             name = name,
             move_x = move_x,
             move_y = move_y,

--- a/src/onpy/features/__init__.py
+++ b/src/onpy/features/__init__.py
@@ -1,6 +1,7 @@
 """OnPy interfaces to OnShape Features."""
 
 from onpy.features.extrude import Extrude
+from onpy.features.translate import Translate
 from onpy.features.loft import Loft
 from onpy.features.planes import DefaultPlane, OffsetPlane, Plane
 from onpy.features.sketch.sketch import Sketch

--- a/src/onpy/features/__init__.py
+++ b/src/onpy/features/__init__.py
@@ -1,17 +1,17 @@
 """OnPy interfaces to OnShape Features."""
 
 from onpy.features.extrude import Extrude
-from onpy.features.translate import Translate
 from onpy.features.loft import Loft
 from onpy.features.planes import DefaultPlane, OffsetPlane, Plane
 from onpy.features.sketch.sketch import Sketch
+from onpy.features.translate import Translate
 
 __all__ = [
     "DefaultPlane",
     "Extrude",
-    "Translate",
     "Loft",
     "OffsetPlane",
     "Plane",
     "Sketch",
+    "Translate",
 ]

--- a/src/onpy/features/__init__.py
+++ b/src/onpy/features/__init__.py
@@ -8,6 +8,7 @@ from onpy.features.sketch.sketch import Sketch
 __all__ = [
     "DefaultPlane",
     "Extrude",
+    "Translate",
     "Loft",
     "OffsetPlane",
     "Plane",

--- a/src/onpy/features/translate.py
+++ b/src/onpy/features/translate.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, override
 from onpy.api import schema
 from onpy.api.schema import FeatureAddResponse
 from onpy.entities import EntityFilter
-from onpy.entities.protocols import BodyEntityConvertible, FaceEntityConvertible
 from onpy.features.base import Feature
 from onpy.part import Part
 from onpy.util.misc import unwrap
@@ -30,6 +29,7 @@ class Translate(Feature):
         x: float,
         y: float,
         z: float,
+        *,
         copy: bool,
         name: str = "Translation",
     ) -> None:
@@ -55,7 +55,6 @@ class Translate(Feature):
         self.copy = copy
 
         self._upload_feature()
-
 
     @property
     @override
@@ -86,45 +85,28 @@ class Translate(Feature):
             featureType="transform",
             suppressed=False,
             parameters=[
-
                 {
                     "btType": "BTMParameterQueryList-148",
                     "parameterId": "entities",
                     "queries": [
-                    {
-                        "btType": "BTMIndividualQuery-138",
-                        "deterministicIds": [self.part.id]
-                    }
-                    ]
+                        {"btType": "BTMIndividualQuery-138", "deterministicIds": [self.part.id]}
+                    ],
                 },
                 {
                     "btType": "BTMParameterEnum-145",
                     "namespace": "",
                     "enumName": "TransformType",
                     "value": "TRANSLATION_3D",
-                    "parameterId": "transformType"
+                    "parameterId": "transformType",
                 },
-                {
-                    "btType": "BTMParameterQuantity-147",
-                    "value": self.x,
-                    "parameterId": "dx"
-                },
-                {
-                    "btType": "BTMParameterQuantity-147",
-                    "value": self.y,
-                    "parameterId": "dy"
-                },
-                {
-                    "btType": "BTMParameterQuantity-147",
-                    "value": self.z,
-                    "parameterId": "dz"
-                },
+                {"btType": "BTMParameterQuantity-147", "value": self.x, "parameterId": "dx"},
+                {"btType": "BTMParameterQuantity-147", "value": self.y, "parameterId": "dy"},
+                {"btType": "BTMParameterQuantity-147", "value": self.z, "parameterId": "dz"},
                 {
                     "btType": "BTMParameterBoolean-144",
                     "value": self.copy,
-                    "parameterId": "makeCopy"
-                }
-
+                    "parameterId": "makeCopy",
+                },
             ],
         )
 

--- a/src/onpy/features/translate.py
+++ b/src/onpy/features/translate.py
@@ -80,38 +80,47 @@ class Translate(Feature):
         return schema.Translate(
             name=self.name,
             featureId=self._id,
+            featureType="transform",
             suppressed=False,
             parameters=[
 
-
                 {
-                "btType": "BTMParameterQuantity-147",
-                "isInteger": false,
-                "value": self.move_,
-                "units": "",
-                "parameterId": "dx",
+                    "btType": "BTMParameterQueryList-148",
+                    "parameterId": "entities",
+                    "queries": [
+                    {
+                        "btType": "BTMIndividualQuery-138",
+                        "deterministicIds": [self.part_id]
+                    }
+                    ]
                 },
                 {
-                "btType": "BTMParameterQuantity-147",
-                "isInteger": false,
-                "value": self.move_y,
-                "units": "",
-                "parameterId": "dy",
+                    "btType": "BTMParameterEnum-145",
+                    "namespace": "",
+                    "enumName": "TransformType",
+                    "value": "TRANSLATION_3D",
+                    "parameterId": "transformType"
                 },
                 {
-                "btType": "BTMParameterQuantity-147",
-                "isInteger": false,
-                "value": self.move_z,
-                "units": "",
-                "parameterId": "dz",
+                    "btType": "BTMParameterQuantity-147",
+                    "value": self.move_x,
+                    "parameterId": "dx"
+                },
+                {
+                    "btType": "BTMParameterQuantity-147",
+                    "value": self.move_y,
+                    "parameterId": "dy"
+                },
+                {
+                    "btType": "BTMParameterQuantity-147",
+                    "value": self.move_z,
+                    "parameterId": "dz"
                 },
                 {
                     "btType": "BTMParameterBoolean-144",
                     "value": self.make_copy,
                     "parameterId": "makeCopy"
                 }
-
-
 
             ],
         )

--- a/src/onpy/features/translate.py
+++ b/src/onpy/features/translate.py
@@ -27,10 +27,10 @@ class Translate(Feature):
         self,
         part: Part,
         partstudio: "PartStudio",
-        move_x: float,
-        move_y: float,
-        move_z: float,
-        copy_part: bool,
+        x: float,
+        y: float,
+        z: float,
+        copy: bool,
         name: str = "Translation",
     ) -> None:
         """Construct an translate feature.
@@ -39,20 +39,20 @@ class Translate(Feature):
             partstudio: The owning partstudio
             part: The part to be tranlsated
             name: The name of the translation feature
-            move_x: The distance to move in x direction
-            move_y: The distance to move in y direction
-            move_z: The distance to move in z direction
-            copy_part: Bool to indicate part should be copied
+            x: The distance to move in x direction
+            y: The distance to move in y direction
+            z: The distance to move in z direction
+            copy: Bool to indicate part should be copied
 
         """
         self._id: str | None = None
         self.part = part
         self._partstudio = partstudio
         self._name = name
-        self.move_x = move_x
-        self.move_y = move_y
-        self.move_z = move_z
-        self.copy_part = copy_part
+        self.x = x
+        self.y = y
+        self.z = z
+        self.copy = copy
 
         self._upload_feature()
 
@@ -106,22 +106,22 @@ class Translate(Feature):
                 },
                 {
                     "btType": "BTMParameterQuantity-147",
-                    "value": self.move_x,
+                    "value": self.x,
                     "parameterId": "dx"
                 },
                 {
                     "btType": "BTMParameterQuantity-147",
-                    "value": self.move_y,
+                    "value": self.y,
                     "parameterId": "dy"
                 },
                 {
                     "btType": "BTMParameterQuantity-147",
-                    "value": self.move_z,
+                    "value": self.z,
                     "parameterId": "dz"
                 },
                 {
                     "btType": "BTMParameterBoolean-144",
-                    "value": self.copy_part,
+                    "value": self.copy,
                     "parameterId": "makeCopy"
                 }
 

--- a/src/onpy/features/translate.py
+++ b/src/onpy/features/translate.py
@@ -25,7 +25,7 @@ class Translate(Feature):
 
     def __init__(
         self,
-        part_id: str,
+        part: Part,
         partstudio: "PartStudio",
         move_x: float,
         move_y: float,
@@ -37,7 +37,7 @@ class Translate(Feature):
 
         Args:
             partstudio: The owning partstudio
-            part_id: The ID of the part to be tranlsated
+            part: The part to be tranlsated
             name: The name of the translation feature
             move_x: The distance to move in x direction
             move_y: The distance to move in y direction
@@ -46,7 +46,7 @@ class Translate(Feature):
 
         """
         self._id: str | None = None
-        self.part_id = part_id
+        self.part = part
         self._partstudio = partstudio
         self._name = name
         self.move_x = move_x
@@ -93,7 +93,7 @@ class Translate(Feature):
                     "queries": [
                     {
                         "btType": "BTMIndividualQuery-138",
-                        "deterministicIds": [self.part_id]
+                        "deterministicIds": [self.part.id]
                     }
                     ]
                 },

--- a/src/onpy/features/translate.py
+++ b/src/onpy/features/translate.py
@@ -25,6 +25,7 @@ class Translate(Feature):
 
     def __init__(
         self,
+        part_id: str,
         partstudio: "PartStudio",
         move_x: float,
         move_y: float,
@@ -36,6 +37,7 @@ class Translate(Feature):
 
         Args:
             partstudio: The owning partstudio
+            part_id: The ID of the part to be tranlsated
             name: The name of the translation feature
             move_x: The distance to move in x direction
             move_y: The distance to move in y direction
@@ -44,6 +46,7 @@ class Translate(Feature):
 
         """
         self._id: str | None = None
+        self.part_id = part_id
         self._partstudio = partstudio
         self._name = name
         self.move_x = move_x

--- a/src/onpy/features/translate.py
+++ b/src/onpy/features/translate.py
@@ -50,9 +50,9 @@ class Translate(Feature):
         self._partstudio = partstudio
         self._name = name
         self.move_x = move_x
-        self._move_y = move_y
-        self._move_z = move_z
-        self._copy_part = copy_part
+        self.move_y = move_y
+        self.move_z = move_z
+        self.copy_part = copy_part
 
         self._upload_feature()
 
@@ -121,7 +121,7 @@ class Translate(Feature):
                 },
                 {
                     "btType": "BTMParameterBoolean-144",
-                    "value": self.make_copy,
+                    "value": self.copy_part,
                     "parameterId": "makeCopy"
                 }
 

--- a/src/onpy/features/translate.py
+++ b/src/onpy/features/translate.py
@@ -1,0 +1,121 @@
+"""Interface to the Translate Feature.
+
+This script defines the Transform - Translate by XYZ feature.
+
+OnPy - May 2025 - David Burns
+
+"""
+
+from typing import TYPE_CHECKING, override
+
+from onpy.api import schema
+from onpy.api.schema import FeatureAddResponse
+from onpy.entities import EntityFilter
+from onpy.entities.protocols import BodyEntityConvertible, FaceEntityConvertible
+from onpy.features.base import Feature
+from onpy.part import Part
+from onpy.util.misc import unwrap
+
+if TYPE_CHECKING:
+    from onpy.elements.partstudio import PartStudio
+
+
+class Translate(Feature):
+    """Represents an translation feature."""
+
+    def __init__(
+        self,
+        partstudio: "PartStudio",
+        move_x: float,
+        move_y: float,
+        move_z: float,
+        copy_part: bool,
+        name: str = "Translation",
+    ) -> None:
+        """Construct an translate feature.
+
+        Args:
+            partstudio: The owning partstudio
+            name: The name of the translation feature
+            move_x: The distance to move in x direction
+            move_y: The distance to move in y direction
+            move_z: The distance to move in z direction
+            copy_part: Bool to indicate part should be copied
+
+        """
+        self._id: str | None = None
+        self._partstudio = partstudio
+        self._name = name
+        self.move_x = move_x
+        self._move_y = move_y
+        self._move_z = move_z
+        self._copy_part = copy_part
+
+        self._upload_feature()
+
+
+    @property
+    @override
+    def id(self) -> str | None:
+        return unwrap(self._id, message="Translate feature id unbound")
+
+    @property
+    @override
+    def partstudio(self) -> "PartStudio":
+        return self._partstudio
+
+    @property
+    @override
+    def name(self) -> str:
+        return self._name
+
+    @property
+    @override
+    def entities(self) -> EntityFilter:
+        # TODO @kyle-tennison: Not currently implemented. Load with items
+        return EntityFilter(self.partstudio, available=[])
+
+    @override
+    def _to_model(self) -> schema.Translate:
+        return schema.Translate(
+            name=self.name,
+            featureId=self._id,
+            suppressed=False,
+            parameters=[
+
+
+                {
+                "btType": "BTMParameterQuantity-147",
+                "isInteger": false,
+                "value": self.move_,
+                "units": "",
+                "parameterId": "dx",
+                },
+                {
+                "btType": "BTMParameterQuantity-147",
+                "isInteger": false,
+                "value": self.move_y,
+                "units": "",
+                "parameterId": "dy",
+                },
+                {
+                "btType": "BTMParameterQuantity-147",
+                "isInteger": false,
+                "value": self.move_z,
+                "units": "",
+                "parameterId": "dz",
+                },
+                {
+                    "btType": "BTMParameterBoolean-144",
+                    "value": self.make_copy,
+                    "parameterId": "makeCopy"
+                }
+
+
+
+            ],
+        )
+
+    @override
+    def _load_response(self, response: FeatureAddResponse) -> None:
+        self._id = response.feature.featureId

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -168,3 +168,21 @@ def test_part_query():
     print(partstudio.parts)
 
     document.delete()
+
+def test_part_translate():
+    """Tests the ability to translate (move and copy) a part"""
+
+    document = onpy.create_document("test_features::test_part_translate")
+    partstudio = document.get_partstudio()
+    partstudio.wipe()
+
+    sketch1 = partstudio.add_sketch(partstudio.features.top_plane)
+    sketch1.add_circle((0, 0), radius=1)
+
+    extrude = partstudio.add_extrude(sketch1, distance=3)
+
+    new_part = extrude.get_created_parts()[0]
+
+    partstudio.add_translate(new_part, x=10, y=80, z=30, copy=True)
+
+    document.delete()

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -184,5 +184,8 @@ def test_part_translate():
     new_part = extrude.get_created_parts()[0]
 
     partstudio.add_translate(new_part, x=10, y=80, z=30, copy=True)
+    partstudio.add_translate(new_part, x=-10, y=-80, z=-30, copy=False)
+
+    assert len(partstudio.parts.parts) == 2
 
     document.delete()


### PR DESCRIPTION
### Description

This PR adds an additional feature add:  `add_translate`.    This does the same operation as "Transform -> Translate by XYZ" in the GUI and operates on an existing part.    I needed this for a project and it was missing so I figured I may as well add it.

This is a part studio endpoint in the API and in the same boat as Extrude so as you may notice I've replicated what `add_extrude` does and changed the necessary parts to make it work.

This might make more sense as a function on a part object but I wanted to keep it consistent with existing functions and the API.   I also tried to keep the arguments consistent with the translate function in sketch.

### Testing

TBC

 