### PR TITLE
Feature:   Added the boolean union feature to union two parts

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -53,7 +53,7 @@ Depending on the circumstance, you can move sketches to other planes using offse
 
 After you have created a sketch, perform some 3D operation on it. Currently, OnPy only supports extrusions and lofts, but these are powerful in their own right. If your sketch has multiple regions, you can query them based on their properties. Queries will be discussed later.
 
-After you have created a 3D object, also known as a Part, you can perform additional queries and operations on it, such as translate (Transform/Translate by XYZ). You can reference part faces, edges, vertices, etc. in order to define additional sketches.
+After you have created a 3D object, also known as a Part, you can perform additional queries and operations on it, such as translate (Transform/Translate by XYZ) or boolean union. You can reference part faces, edges, vertices, etc. in order to define additional sketches.
 
 ## Defining a Sketch
 
@@ -511,6 +511,24 @@ def add_translate(
 
     """
 
+def add_boolean_union(
+    self,
+    parts: Part,
+    name: str = "New Boolean Union",
+    keep_tools: bool = False,
+) -> BooleanUnion:
+    """Add a new boolean of type union feature to the partstudio.
+
+    Args:
+        parts: An array of parts to be unioned
+        name: The name of the extrusion feature
+        keep_tools: Bool to indicate if tools should be kept (same as GUI checkbox)
+
+    Returns:
+        An Unioned object
+
+    """
+
 def add_loft(
     self,
     start: FaceEntityConvertible,
@@ -702,6 +720,19 @@ part = partstudio.parts.get('triangle')
 partstudio.add_translate(part,x=10,y=80,z=30,copy=True)
 ```
 
+### Boolean Union
+
+This function does a boolean union of two or more intersecting parts with a "keep_tools" option like the checkbox in the GUI.
+
+```python
+# identify two parts
+part1 = partstudio.parts.get('triangle')
+part2 = partstudio.parts.get('square')
+
+# Union them together
+partstudio.add_boolean_union(name="My perfect union",parts=[part1,part2],keep_tools=False)
+```
+
 ## Parts
 
 Sometimes, features will result in a new part. For instance, when you extrude a sketch for the first time, a new part is made.
@@ -726,7 +757,7 @@ with parts. If you want to get an idea of what parts are available, you can run:
 This will display the parts available. Then, you can access the parts by index (`partstudio.parts[0]`),
 name (`partstudio.parts.get("Housing")`), or id (`partstudio.parts.get_id("JKD")`)
 
-You can use the partudio `add_translate` function to move or copy the part.
+You can use the partudio `add_translate` function to move or copy the part or `add_boolean_union` to union two or more parts.
 
 If you want to manually iterate over a list of parts, you can call `partstudio.list_parts()`
 and this will return a plain list of Part objects.

--- a/guide.md
+++ b/guide.md
@@ -53,7 +53,7 @@ Depending on the circumstance, you can move sketches to other planes using offse
 
 After you have created a sketch, perform some 3D operation on it. Currently, OnPy only supports extrusions and lofts, but these are powerful in their own right. If your sketch has multiple regions, you can query them based on their properties. Queries will be discussed later.
 
-After you have created a 3D object, also known as a Part, you can perform additional queries and operations on it. You can reference part faces, edges, vertices, etc. in order to define additional sketches.
+After you have created a 3D object, also known as a Part, you can perform additional queries and operations on it, such as translate (Transform/Translate by XYZ). You can reference part faces, edges, vertices, etc. in order to define additional sketches.
 
 ## Defining a Sketch
 
@@ -487,6 +487,30 @@ def add_extrude(
     """
     ...
 
+def add_translate(
+    self,
+    part: Part,
+    name: str = "New Translate",
+    x: float = 0,
+    y: float = 0,
+    z: float = 0,
+    copy: bool = False,
+) -> Translate:
+    """Add a new transform of type translate_xyz feature to the partstudio.
+
+    Args:
+        part: The part to be translated
+        name: The name of the extrusion feature
+        x: The distance to move in x direction
+        y: The distance to move in y direction
+        z: The distance to move in z direction
+        copy: Bool to indicate part should be copied
+
+    Returns:
+        An Translated object
+
+    """
+
 def add_loft(
     self,
     start: FaceEntityConvertible,
@@ -662,6 +686,22 @@ often leads to feature errors.
 Lofts take two parameters, start and end, with a third, optional name parameter.
 The example above in the "Offset Plane" section exemplifies how to use lofts.
 
+### Translate
+
+A translate operates on an existing part (an object in part studio).  This is the "Transform" function of type
+"Translate by XYZ" present in the GUI.
+
+This will esentially move a part by the specified x,y,z units (uses default units of the document), with an option
+to "copy" the part (same as "Copy Part" checkbox in GUI)
+
+```python
+# get the part from part studio with the name of "triangle"
+part = partstudio.parts.get('triangle')
+
+# Create a copy of the part and move it 10,80,30 in the x,y,z directions
+partstudio.add_translate(part,x=10,y=80,z=30,copy=True)
+```
+
 ## Parts
 
 Sometimes, features will result in a new part. For instance, when you extrude a sketch for the first time, a new part is made.
@@ -685,6 +725,8 @@ with parts. If you want to get an idea of what parts are available, you can run:
 
 This will display the parts available. Then, you can access the parts by index (`partstudio.parts[0]`),
 name (`partstudio.parts.get("Housing")`), or id (`partstudio.parts.get_id("JKD")`)
+
+You can use the partudio `add_translate` function to move or copy the part.
 
 If you want to manually iterate over a list of parts, you can call `partstudio.list_parts()`
 and this will return a plain list of Part objects.

--- a/guide.md
+++ b/guide.md
@@ -507,7 +507,7 @@ def add_translate(
         copy: Bool to indicate part should be copied
 
     Returns:
-        An Translated object
+        A Translated object
 
     """
 

--- a/src/onpy/api/schema.py
+++ b/src/onpy/api/schema.py
@@ -224,7 +224,7 @@ class Sketch(Feature):
     entities: list[dict] | None  # dict is FeatureEntity
 
 class Extrude(Feature):
-    """Represents an Translate Feature."""
+    """Represents an Extrude Feature."""
 
     btType: str = "BTMFeature-134"
     featureType: str = "extrude"

--- a/src/onpy/api/schema.py
+++ b/src/onpy/api/schema.py
@@ -229,12 +229,6 @@ class Extrude(Feature):
     btType: str = "BTMFeature-134"
     featureType: str = "extrude"
 
-class Translate(Feature):
-    """Represents an Translate Feature."""
-
-    btType: str = "BTMFeature-134"
-    featureType: str = "transform"
-
 class BooleanUnion(Feature):
     """Represents an Boolean Union Feature."""
 

--- a/src/onpy/api/schema.py
+++ b/src/onpy/api/schema.py
@@ -223,13 +223,17 @@ class Sketch(Feature):
     constraints: list[dict] | None = []
     entities: list[dict] | None  # dict is FeatureEntity
 
-
 class Extrude(Feature):
-    """Represents an Extrude Feature."""
+    """Represents an Translate Feature."""
 
     btType: str = "BTMFeature-134"
     featureType: str = "extrude"
 
+class Translate(Feature):
+    """Represents an Translate Feature."""
+
+    btType: str = "BTMFeature-134"
+    featureType: str = "transform"
 
 class Plane(Feature):
     """Represents a Plane Feature."""

--- a/src/onpy/api/schema.py
+++ b/src/onpy/api/schema.py
@@ -235,6 +235,12 @@ class Translate(Feature):
     btType: str = "BTMFeature-134"
     featureType: str = "transform"
 
+class BooleanUnion(Feature):
+    """Represents an Boolean Union Feature."""
+
+    btType: str = "BTMFeature-134"
+    featureType: str = "booleanBodies"
+
 class Plane(Feature):
     """Represents a Plane Feature."""
 

--- a/src/onpy/api/schema.py
+++ b/src/onpy/api/schema.py
@@ -39,6 +39,10 @@ class NameIdFetchable(Protocol):
         """The ID of the item."""
         ...
 
+    def __hash__(self) -> int:
+        """Generate a unique hash for the object."""
+        return hash(self.id)
+
 
 class ApiModel(BaseModel):
     """Base model for OnShape APIs."""

--- a/src/onpy/api/schema.py
+++ b/src/onpy/api/schema.py
@@ -223,17 +223,20 @@ class Sketch(Feature):
     constraints: list[dict] | None = []
     entities: list[dict] | None  # dict is FeatureEntity
 
+
 class Extrude(Feature):
     """Represents an Extrude Feature."""
 
     btType: str = "BTMFeature-134"
     featureType: str = "extrude"
 
+
 class BooleanUnion(Feature):
     """Represents an Boolean Union Feature."""
 
     btType: str = "BTMFeature-134"
     featureType: str = "booleanBodies"
+
 
 class Translate(Feature):
     """Represents an Translate Feature."""

--- a/src/onpy/document.py
+++ b/src/onpy/document.py
@@ -141,3 +141,7 @@ class Document(schema.NameIdFetchable):
     def __eq__(self, other: object) -> bool:
         """Check if two documents are the same."""
         return type(other) is type(self) and self.id == getattr(other, "id", None)
+
+    def __hash__(self) -> int:
+        """Generate a unique hash for the document."""
+        return hash(self.id)

--- a/src/onpy/elements/base.py
+++ b/src/onpy/elements/base.py
@@ -64,3 +64,7 @@ class Element(ABC, schema.NameIdFetchable):
         if isinstance(other, type(self)):
             return other.id == self.id and type(other) is type(self)
         return False
+
+    def __hash__(self) -> int:
+        """Generate a unique hash for the element."""
+        return hash(self.id)

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -120,6 +120,36 @@ class PartStudio(Element):
             subtract_from=subtract_from,
         )
 
+    def add_translate(
+        self,
+        name: str = "New Extrude",
+        move_x: float,
+        move_y: float,
+        move_z: float,
+        copy_part: bool,
+    ) -> Translate:
+        """Add a new transform of type translate_xyz feature to the partstudio.
+
+        Args:
+            name: The name of the extrusion feature
+            move_x: The distance to move in x direction
+            move_y: The distance to move in y direction
+            move_z: The distance to move in z direction
+            copy_part: Bool to indicate part should be copied
+
+        Returns:
+            An Translated object
+
+        """
+        return Translate(
+            partstudio = self,
+            name = name,
+            move_x = move_x,
+            move_y = move_y,
+            move_z = move_z,
+            copy_part = copy_part,
+        )
+
     def add_loft(
         self,
         start: FaceEntityConvertible,

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -124,20 +124,20 @@ class PartStudio(Element):
         self,
         part: Part,
         name: str = "New Translate",
-        move_x: float = 0,
-        move_y: float = 0,
-        move_z: float = 0,
-        copy_part: bool = False,
+        x: float = 0,
+        y: float = 0,
+        z: float = 0,
+        copy: bool = False,
     ) -> Translate:
         """Add a new transform of type translate_xyz feature to the partstudio.
 
         Args:
             part: The part to be translated
             name: The name of the extrusion feature
-            move_x: The distance to move in x direction
-            move_y: The distance to move in y direction
-            move_z: The distance to move in z direction
-            copy_part: Bool to indicate part should be copied
+            x: The distance to move in x direction
+            y: The distance to move in y direction
+            z: The distance to move in z direction
+            copy: Bool to indicate part should be copied
 
         Returns:
             An Translated object
@@ -147,10 +147,10 @@ class PartStudio(Element):
             partstudio = self,
             part = part,
             name = name,
-            move_x = move_x,
-            move_y = move_y,
-            move_z = move_z,
-            copy_part = copy_part,
+            x = x,
+            y = y,
+            z = z,
+            copy = copy,
         )
 
     def add_loft(

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -122,7 +122,7 @@ class PartStudio(Element):
 
     def add_translate(
         self,
-        part_id: str,
+        part: Part,
         name: str = "New Translate",
         move_x: float = 0,
         move_y: float = 0,
@@ -132,7 +132,7 @@ class PartStudio(Element):
         """Add a new transform of type translate_xyz feature to the partstudio.
 
         Args:
-            part_id: The id of the part to be translated
+            part: The part to be translated
             name: The name of the extrusion feature
             move_x: The distance to move in x direction
             move_y: The distance to move in y direction
@@ -145,7 +145,7 @@ class PartStudio(Element):
         """
         return Translate(
             partstudio = self,
-            part_id = part_id,
+            part = part,
             name = name,
             move_x = move_x,
             move_y = move_y,

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -15,7 +15,7 @@ from onpy.api import schema
 from onpy.api.versioning import WorkspaceWVM
 from onpy.elements.base import Element
 from onpy.entities.protocols import BodyEntityConvertible, FaceEntityConvertible
-from onpy.features import Extrude, Loft, OffsetPlane, Plane, Sketch
+from onpy.features import Extrude, Translate, Loft, OffsetPlane, Plane, Sketch
 from onpy.features.base import Feature, FeatureList
 from onpy.features.planes import DefaultPlane, DefaultPlaneOrientation
 from onpy.part import Part, PartList
@@ -123,10 +123,10 @@ class PartStudio(Element):
     def add_translate(
         self,
         name: str = "New Extrude",
-        move_x: float,
-        move_y: float,
-        move_z: float,
-        copy_part: bool,
+        move_x: float = 0,
+        move_y: float = 0,
+        move_z: float = 0,
+        copy_part: bool = False,
     ) -> Translate:
         """Add a new transform of type translate_xyz feature to the partstudio.
 

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -123,7 +123,7 @@ class PartStudio(Element):
     def add_translate(
         self,
         part_id: str,
-        name: str = "New Extrude",
+        name: str = "New Translate",
         move_x: float = 0,
         move_y: float = 0,
         move_z: float = 0,

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -122,6 +122,7 @@ class PartStudio(Element):
 
     def add_translate(
         self,
+        part_id: str,
         name: str = "New Extrude",
         move_x: float = 0,
         move_y: float = 0,
@@ -131,6 +132,7 @@ class PartStudio(Element):
         """Add a new transform of type translate_xyz feature to the partstudio.
 
         Args:
+            part_id: The id of the part to be translated
             name: The name of the extrusion feature
             move_x: The distance to move in x direction
             move_y: The distance to move in y direction
@@ -143,6 +145,7 @@ class PartStudio(Element):
         """
         return Translate(
             partstudio = self,
+            part_id = part_id,
             name = name,
             move_x = move_x,
             move_y = move_y,

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -15,7 +15,7 @@ from onpy.api import schema
 from onpy.api.versioning import WorkspaceWVM
 from onpy.elements.base import Element
 from onpy.entities.protocols import BodyEntityConvertible, FaceEntityConvertible
-from onpy.features import Extrude, Translate, Loft, OffsetPlane, Plane, Sketch
+from onpy.features import Extrude, Translate, Loft, OffsetPlane, Plane, Sketch, BooleanUnion
 from onpy.features.base import Feature, FeatureList
 from onpy.features.planes import DefaultPlane, DefaultPlaneOrientation
 from onpy.part import Part, PartList
@@ -151,6 +151,30 @@ class PartStudio(Element):
             y = y,
             z = z,
             copy = copy,
+        )
+
+    def add_boolean_union(
+        self,
+        parts: Part,
+        name: str = "New Boolean Union",
+        keep_tools: bool = False,
+    ) -> BooleanUnion:
+        """Add a new boolean of type union feature to the partstudio.
+
+        Args:
+            parts: An array of parts to be unioned
+            name: The name of the extrusion feature
+            keep_tools: Bool to indicate if tools should be kept (same as GUI checkbox)
+
+        Returns:
+            An Unioned object
+
+        """
+        return BooleanUnion(
+            partstudio = self,
+            parts = parts,
+            name = name,
+            keep_tools = keep_tools,
         )
 
     def add_loft(

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -145,13 +145,13 @@ class PartStudio(Element):
 
         """
         return Translate(
-            partstudio = self,
-            part = part,
-            name = name,
-            x = x,
-            y = y,
-            z = z,
-            copy = copy,
+            partstudio=self,
+            part=part,
+            name=name,
+            x=x,
+            y=y,
+            z=z,
+            copy=copy,
         )
 
     def add_boolean_union(
@@ -172,10 +172,10 @@ class PartStudio(Element):
 
         """
         return BooleanUnion(
-            partstudio = self,
-            parts = parts,
-            name = name,
-            keep_tools = keep_tools,
+            partstudio=self,
+            parts=parts,
+            name=name,
+            keep_tools=keep_tools,
         )
 
     def add_loft(

--- a/src/onpy/elements/partstudio.py
+++ b/src/onpy/elements/partstudio.py
@@ -15,7 +15,7 @@ from onpy.api import schema
 from onpy.api.versioning import WorkspaceWVM
 from onpy.elements.base import Element
 from onpy.entities.protocols import BodyEntityConvertible, FaceEntityConvertible
-from onpy.features import Extrude, Translate, BooleanUnion, Loft, OffsetPlane, Plane, Sketch
+from onpy.features import BooleanUnion, Extrude, Loft, OffsetPlane, Plane, Sketch, Translate
 from onpy.features.base import Feature, FeatureList
 from onpy.features.planes import DefaultPlane, DefaultPlaneOrientation
 from onpy.part import Part, PartList
@@ -156,8 +156,9 @@ class PartStudio(Element):
 
     def add_boolean_union(
         self,
-        parts: Part,
+        parts: list[Part],
         name: str = "New Boolean Union",
+        *,
         keep_tools: bool = False,
     ) -> BooleanUnion:
         """Add a new boolean of type union feature to the partstudio.

--- a/src/onpy/features/__init__.py
+++ b/src/onpy/features/__init__.py
@@ -1,6 +1,7 @@
 """OnPy interfaces to OnShape Features."""
 
 from onpy.features.extrude import Extrude
+from onpy.features.translate import Translate
 from onpy.features.loft import Loft
 from onpy.features.planes import DefaultPlane, OffsetPlane, Plane
 from onpy.features.sketch.sketch import Sketch

--- a/src/onpy/features/__init__.py
+++ b/src/onpy/features/__init__.py
@@ -8,6 +8,7 @@ from onpy.features.sketch.sketch import Sketch
 __all__ = [
     "DefaultPlane",
     "Extrude",
+    "Translate",
     "Loft",
     "OffsetPlane",
     "Plane",

--- a/src/onpy/features/__init__.py
+++ b/src/onpy/features/__init__.py
@@ -6,7 +6,6 @@ from onpy.features.booleanunion import BooleanUnion
 from onpy.features.loft import Loft
 from onpy.features.planes import DefaultPlane, OffsetPlane, Plane
 from onpy.features.sketch.sketch import Sketch
-from onpy.features.translate import Translate
 
 __all__ = [
     "DefaultPlane",
@@ -17,5 +16,4 @@ __all__ = [
     "OffsetPlane",
     "Plane",
     "Sketch",
-    "Translate",
 ]

--- a/src/onpy/features/__init__.py
+++ b/src/onpy/features/__init__.py
@@ -2,6 +2,7 @@
 
 from onpy.features.extrude import Extrude
 from onpy.features.translate import Translate
+from onpy.features.booleanunion import BooleanUnion
 from onpy.features.loft import Loft
 from onpy.features.planes import DefaultPlane, OffsetPlane, Plane
 from onpy.features.sketch.sketch import Sketch
@@ -10,6 +11,7 @@ __all__ = [
     "DefaultPlane",
     "Extrude",
     "Translate",
+    "BooleanUnion",
     "Loft",
     "OffsetPlane",
     "Plane",

--- a/src/onpy/features/__init__.py
+++ b/src/onpy/features/__init__.py
@@ -1,19 +1,19 @@
 """OnPy interfaces to OnShape Features."""
 
-from onpy.features.extrude import Extrude
-from onpy.features.translate import Translate
 from onpy.features.booleanunion import BooleanUnion
+from onpy.features.extrude import Extrude
 from onpy.features.loft import Loft
 from onpy.features.planes import DefaultPlane, OffsetPlane, Plane
 from onpy.features.sketch.sketch import Sketch
+from onpy.features.translate import Translate
 
 __all__ = [
+    "BooleanUnion",
     "DefaultPlane",
     "Extrude",
-    "Translate",
-    "BooleanUnion",
     "Loft",
     "OffsetPlane",
     "Plane",
     "Sketch",
+    "Translate",
 ]

--- a/src/onpy/features/booleanunion.py
+++ b/src/onpy/features/booleanunion.py
@@ -27,6 +27,7 @@ class BooleanUnion(Feature):
         self,
         parts: Part,
         partstudio: "PartStudio",
+        *,
         keep_tools: bool,
         name: str = "BooleanUnion",
     ) -> None:

--- a/src/onpy/features/booleanunion.py
+++ b/src/onpy/features/booleanunion.py
@@ -1,0 +1,106 @@
+"""Interface to the Boolean Union Feature.
+
+This script defines the Boolean - Union
+
+OnPy - May 2025 - David Burns
+
+"""
+
+from typing import TYPE_CHECKING, override
+
+from onpy.api import schema
+from onpy.api.schema import FeatureAddResponse
+from onpy.entities import EntityFilter
+from onpy.entities.protocols import BodyEntityConvertible, FaceEntityConvertible
+from onpy.features.base import Feature
+from onpy.part import Part
+from onpy.util.misc import unwrap
+
+if TYPE_CHECKING:
+    from onpy.elements.partstudio import PartStudio
+
+
+class BooleanUnion(Feature):
+    """Represents an translation feature."""
+
+    def __init__(
+        self,
+        parts: Part,
+        partstudio: "PartStudio",
+        keep_tools: bool,
+        name: str = "BooleanUnion",
+    ) -> None:
+        """Construct an boolean union feature.
+
+        Args:
+            partstudio: The owning partstudio
+            parts: An array of parts to be unioned
+            name: The name of the boolean union feature
+            keep_tools: Bool to indicate if tools to be kept (same as GUI checkbox)
+
+        """
+        self._id: str | None = None
+        self.parts = parts
+        self._partstudio = partstudio
+        self._name = name
+        self.keep_tools = keep_tools
+
+        self._upload_feature()
+
+
+    @property
+    @override
+    def id(self) -> str | None:
+        return unwrap(self._id, message="BooleanUnion feature id unbound")
+
+    @property
+    @override
+    def partstudio(self) -> "PartStudio":
+        return self._partstudio
+
+    @property
+    @override
+    def name(self) -> str:
+        return self._name
+
+    @property
+    @override
+    def entities(self) -> EntityFilter:
+        # TODO @kyle-tennison: Not currently implemented. Load with items
+        return EntityFilter(self.partstudio, available=[])
+
+    @override
+    def _to_model(self) -> schema.Translate:
+
+        part_ids = [p.id for p in self.parts]
+
+        return schema.Translate(
+            name=self.name,
+            featureId=self._id,
+            featureType="booleanBodies",
+            suppressed=False,
+            parameters=[
+
+
+                {
+                    "btType": "BTMParameterEnum-145",
+                    "enumName": "BooleanOperationType",
+                    "value": "UNION",
+                    "parameterId": "operationType"
+                },
+                {
+                    "btType": "BTMParameterQueryList-148",
+                    "parameterId": "tools",
+                    "queries": [
+                        {"btType": "BTMIndividualQuery-138", "deterministicIds": part_ids}
+                    ]
+                },
+                {"btType": "BTMParameterBoolean-144", "value": self.keep_tools, "parameterId": "keepTools"}
+
+
+            ],
+        )
+
+    @override
+    def _load_response(self, response: FeatureAddResponse) -> None:
+        self._id = response.feature.featureId

--- a/src/onpy/features/booleanunion.py
+++ b/src/onpy/features/booleanunion.py
@@ -48,7 +48,6 @@ class BooleanUnion(Feature):
 
         self._upload_feature()
 
-
     @property
     @override
     def id(self) -> str | None:
@@ -72,7 +71,6 @@ class BooleanUnion(Feature):
 
     @override
     def _to_model(self) -> schema.Translate:
-
         part_ids = [p.id for p in self.parts]
 
         return schema.Translate(
@@ -81,24 +79,22 @@ class BooleanUnion(Feature):
             featureType="booleanBodies",
             suppressed=False,
             parameters=[
-
-
                 {
                     "btType": "BTMParameterEnum-145",
                     "enumName": "BooleanOperationType",
                     "value": "UNION",
-                    "parameterId": "operationType"
+                    "parameterId": "operationType",
                 },
                 {
                     "btType": "BTMParameterQueryList-148",
                     "parameterId": "tools",
-                    "queries": [
-                        {"btType": "BTMIndividualQuery-138", "deterministicIds": part_ids}
-                    ]
+                    "queries": [{"btType": "BTMIndividualQuery-138", "deterministicIds": part_ids}],
                 },
-                {"btType": "BTMParameterBoolean-144", "value": self.keep_tools, "parameterId": "keepTools"}
-
-
+                {
+                    "btType": "BTMParameterBoolean-144",
+                    "value": self.keep_tools,
+                    "parameterId": "keepTools",
+                },
             ],
         )
 

--- a/src/onpy/features/booleanunion.py
+++ b/src/onpy/features/booleanunion.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, override
 from onpy.api import schema
 from onpy.api.schema import FeatureAddResponse
 from onpy.entities import EntityFilter
-from onpy.entities.protocols import BodyEntityConvertible, FaceEntityConvertible
 from onpy.features.base import Feature
 from onpy.part import Part
 from onpy.util.misc import unwrap
@@ -25,7 +24,7 @@ class BooleanUnion(Feature):
 
     def __init__(
         self,
-        parts: Part,
+        parts: list[Part],
         partstudio: "PartStudio",
         *,
         keep_tools: bool,

--- a/src/onpy/features/translate.py
+++ b/src/onpy/features/translate.py
@@ -80,38 +80,47 @@ class Translate(Feature):
         return schema.Translate(
             name=self.name,
             featureId=self._id,
+            featureType="transform",
             suppressed=False,
             parameters=[
 
-
                 {
-                "btType": "BTMParameterQuantity-147",
-                "isInteger": false,
-                "value": self.move_,
-                "units": "",
-                "parameterId": "dx",
+                    "btType": "BTMParameterQueryList-148",
+                    "parameterId": "entities",
+                    "queries": [
+                    {
+                        "btType": "BTMIndividualQuery-138",
+                        "deterministicIds": [self.part_id]
+                    }
+                    ]
                 },
                 {
-                "btType": "BTMParameterQuantity-147",
-                "isInteger": false,
-                "value": self.move_y,
-                "units": "",
-                "parameterId": "dy",
+                    "btType": "BTMParameterEnum-145",
+                    "namespace": "",
+                    "enumName": "TransformType",
+                    "value": "TRANSLATION_3D",
+                    "parameterId": "transformType"
                 },
                 {
-                "btType": "BTMParameterQuantity-147",
-                "isInteger": false,
-                "value": self.move_z,
-                "units": "",
-                "parameterId": "dz",
+                    "btType": "BTMParameterQuantity-147",
+                    "value": self.move_x,
+                    "parameterId": "dx"
+                },
+                {
+                    "btType": "BTMParameterQuantity-147",
+                    "value": self.move_y,
+                    "parameterId": "dy"
+                },
+                {
+                    "btType": "BTMParameterQuantity-147",
+                    "value": self.move_z,
+                    "parameterId": "dz"
                 },
                 {
                     "btType": "BTMParameterBoolean-144",
                     "value": self.make_copy,
                     "parameterId": "makeCopy"
                 }
-
-
 
             ],
         )

--- a/src/onpy/features/translate.py
+++ b/src/onpy/features/translate.py
@@ -27,10 +27,10 @@ class Translate(Feature):
         self,
         part: Part,
         partstudio: "PartStudio",
-        move_x: float,
-        move_y: float,
-        move_z: float,
-        copy_part: bool,
+        x: float,
+        y: float,
+        z: float,
+        copy: bool,
         name: str = "Translation",
     ) -> None:
         """Construct an translate feature.
@@ -39,20 +39,20 @@ class Translate(Feature):
             partstudio: The owning partstudio
             part: The part to be tranlsated
             name: The name of the translation feature
-            move_x: The distance to move in x direction
-            move_y: The distance to move in y direction
-            move_z: The distance to move in z direction
-            copy_part: Bool to indicate part should be copied
+            x: The distance to move in x direction
+            y: The distance to move in y direction
+            z: The distance to move in z direction
+            copy: Bool to indicate part should be copied
 
         """
         self._id: str | None = None
         self.part = part
         self._partstudio = partstudio
         self._name = name
-        self.move_x = move_x
-        self.move_y = move_y
-        self.move_z = move_z
-        self.copy_part = copy_part
+        self.x = x
+        self.y = y
+        self.z = z
+        self.copy = copy
 
         self._upload_feature()
 
@@ -106,22 +106,22 @@ class Translate(Feature):
                 },
                 {
                     "btType": "BTMParameterQuantity-147",
-                    "value": self.move_x,
+                    "value": self.x,
                     "parameterId": "dx"
                 },
                 {
                     "btType": "BTMParameterQuantity-147",
-                    "value": self.move_y,
+                    "value": self.y,
                     "parameterId": "dy"
                 },
                 {
                     "btType": "BTMParameterQuantity-147",
-                    "value": self.move_z,
+                    "value": self.z,
                     "parameterId": "dz"
                 },
                 {
                     "btType": "BTMParameterBoolean-144",
-                    "value": self.copy_part,
+                    "value": self.copy,
                     "parameterId": "makeCopy"
                 }
 

--- a/src/onpy/features/translate.py
+++ b/src/onpy/features/translate.py
@@ -25,7 +25,7 @@ class Translate(Feature):
 
     def __init__(
         self,
-        part_id: str,
+        part: Part,
         partstudio: "PartStudio",
         move_x: float,
         move_y: float,
@@ -37,7 +37,7 @@ class Translate(Feature):
 
         Args:
             partstudio: The owning partstudio
-            part_id: The ID of the part to be tranlsated
+            part: The part to be tranlsated
             name: The name of the translation feature
             move_x: The distance to move in x direction
             move_y: The distance to move in y direction
@@ -46,7 +46,7 @@ class Translate(Feature):
 
         """
         self._id: str | None = None
-        self.part_id = part_id
+        self.part = part
         self._partstudio = partstudio
         self._name = name
         self.move_x = move_x
@@ -93,7 +93,7 @@ class Translate(Feature):
                     "queries": [
                     {
                         "btType": "BTMIndividualQuery-138",
-                        "deterministicIds": [self.part_id]
+                        "deterministicIds": [self.part.id]
                     }
                     ]
                 },

--- a/src/onpy/features/translate.py
+++ b/src/onpy/features/translate.py
@@ -25,6 +25,7 @@ class Translate(Feature):
 
     def __init__(
         self,
+        part_id: str,
         partstudio: "PartStudio",
         move_x: float,
         move_y: float,
@@ -36,6 +37,7 @@ class Translate(Feature):
 
         Args:
             partstudio: The owning partstudio
+            part_id: The ID of the part to be tranlsated
             name: The name of the translation feature
             move_x: The distance to move in x direction
             move_y: The distance to move in y direction
@@ -44,6 +46,7 @@ class Translate(Feature):
 
         """
         self._id: str | None = None
+        self.part_id = part_id
         self._partstudio = partstudio
         self._name = name
         self.move_x = move_x

--- a/src/onpy/features/translate.py
+++ b/src/onpy/features/translate.py
@@ -50,9 +50,9 @@ class Translate(Feature):
         self._partstudio = partstudio
         self._name = name
         self.move_x = move_x
-        self._move_y = move_y
-        self._move_z = move_z
-        self._copy_part = copy_part
+        self.move_y = move_y
+        self.move_z = move_z
+        self.copy_part = copy_part
 
         self._upload_feature()
 
@@ -121,7 +121,7 @@ class Translate(Feature):
                 },
                 {
                     "btType": "BTMParameterBoolean-144",
-                    "value": self.make_copy,
+                    "value": self.copy_part,
                     "parameterId": "makeCopy"
                 }
 

--- a/src/onpy/features/translate.py
+++ b/src/onpy/features/translate.py
@@ -1,0 +1,121 @@
+"""Interface to the Translate Feature.
+
+This script defines the Transform - Translate by XYZ feature.
+
+OnPy - May 2025 - David Burns
+
+"""
+
+from typing import TYPE_CHECKING, override
+
+from onpy.api import schema
+from onpy.api.schema import FeatureAddResponse
+from onpy.entities import EntityFilter
+from onpy.entities.protocols import BodyEntityConvertible, FaceEntityConvertible
+from onpy.features.base import Feature
+from onpy.part import Part
+from onpy.util.misc import unwrap
+
+if TYPE_CHECKING:
+    from onpy.elements.partstudio import PartStudio
+
+
+class Translate(Feature):
+    """Represents an translation feature."""
+
+    def __init__(
+        self,
+        partstudio: "PartStudio",
+        move_x: float,
+        move_y: float,
+        move_z: float,
+        copy_part: bool,
+        name: str = "Translation",
+    ) -> None:
+        """Construct an translate feature.
+
+        Args:
+            partstudio: The owning partstudio
+            name: The name of the translation feature
+            move_x: The distance to move in x direction
+            move_y: The distance to move in y direction
+            move_z: The distance to move in z direction
+            copy_part: Bool to indicate part should be copied
+
+        """
+        self._id: str | None = None
+        self._partstudio = partstudio
+        self._name = name
+        self.move_x = move_x
+        self._move_y = move_y
+        self._move_z = move_z
+        self._copy_part = copy_part
+
+        self._upload_feature()
+
+
+    @property
+    @override
+    def id(self) -> str | None:
+        return unwrap(self._id, message="Translate feature id unbound")
+
+    @property
+    @override
+    def partstudio(self) -> "PartStudio":
+        return self._partstudio
+
+    @property
+    @override
+    def name(self) -> str:
+        return self._name
+
+    @property
+    @override
+    def entities(self) -> EntityFilter:
+        # TODO @kyle-tennison: Not currently implemented. Load with items
+        return EntityFilter(self.partstudio, available=[])
+
+    @override
+    def _to_model(self) -> schema.Translate:
+        return schema.Translate(
+            name=self.name,
+            featureId=self._id,
+            suppressed=False,
+            parameters=[
+
+
+                {
+                "btType": "BTMParameterQuantity-147",
+                "isInteger": false,
+                "value": self.move_,
+                "units": "",
+                "parameterId": "dx",
+                },
+                {
+                "btType": "BTMParameterQuantity-147",
+                "isInteger": false,
+                "value": self.move_y,
+                "units": "",
+                "parameterId": "dy",
+                },
+                {
+                "btType": "BTMParameterQuantity-147",
+                "isInteger": false,
+                "value": self.move_z,
+                "units": "",
+                "parameterId": "dz",
+                },
+                {
+                    "btType": "BTMParameterBoolean-144",
+                    "value": self.make_copy,
+                    "parameterId": "makeCopy"
+                }
+
+
+
+            ],
+        )
+
+    @override
+    def _load_response(self, response: FeatureAddResponse) -> None:
+        self._id = response.feature.featureId

--- a/src/onpy/util/misc.py
+++ b/src/onpy/util/misc.py
@@ -156,6 +156,10 @@ class Point2D:
             return self.x == other.x and self.y == other.y
         return False
 
+    def __hash__(self) -> int:
+        """Generate a unique hash for the point."""
+        return hash((self.x, self.y))
+
     @classmethod
     def from_pair(cls, pair: tuple[float, float]) -> Self:
         """Create a point from an ordered pair."""

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -168,3 +168,21 @@ def test_part_query():
     print(partstudio.parts)
 
     document.delete()
+
+def test_part_translate():
+    """Tests the ability to translate (move and copy) a part"""
+
+    document = onpy.create_document("test_features::test_part_translate")
+    partstudio = document.get_partstudio()
+    partstudio.wipe()
+
+    sketch1 = partstudio.add_sketch(partstudio.features.top_plane)
+    sketch1.add_circle((0, 0), radius=1)
+
+    extrude = partstudio.add_extrude(sketch1, distance=3)
+
+    new_part = extrude.get_created_parts()[0]
+
+    partstudio.add_translate(new_part, x=10, y=80, z=30, copy=True)
+
+    document.delete()

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -186,3 +186,25 @@ def test_part_translate():
     partstudio.add_translate(new_part, x=10, y=80, z=30, copy=True)
 
     document.delete()
+
+def test_part_boolean_union():
+    """Tests the ability to union two intersecting parts"""
+
+    document = onpy.create_document("test_features::test_part_boolean_union")
+    partstudio = document.get_partstudio()
+    partstudio.wipe()
+
+    sketch1 = partstudio.add_sketch(partstudio.features.top_plane)
+    sketch1.add_circle((0, 0), radius=60)
+
+    extrude = partstudio.add_extrude(sketch1, distance=60)
+
+    first_part = extrude.get_created_parts()[0]
+
+    partstudio.add_translate(new_part, x=10, y=0, z=0, copy=True)
+
+    second_part = partstudio.parts[-1]
+
+    partstudio.add_boolean_union(parts=[first_part,second_part],keep_tools=False)
+
+    document.delete()

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -203,7 +203,7 @@ def test_part_boolean_union():
 
     first_part = extrude.get_created_parts()[0]
 
-    partstudio.add_translate(new_part, x=10, y=0, z=0, copy=True)
+    partstudio.add_translate(first_part, x=10, y=0, z=0, copy=True)
 
     second_part = partstudio.parts[-1]
 


### PR DESCRIPTION
# Description

So it seems I need a boolean union in my project so I've added it here to onpy.   This PR adds the specific boolean union feature which allows the joining of two parts.   Like with the translate, I've tried to replicate existing code.   I've attempted to keep the cleanups you added to my previous PR but it's best to check it over as I don't fully comprehend it all.

# Doco

I've updated the `guide.md` to include an example and mention it in the relevant parts.   Hopefully it should be enough to get most users going.

# Tests

I've added a test in the pytests which should in theory work.   I haven't been able to get the drawing of a circle to work from the existing functionality at that is used for the basis of creating parts on most of the tests.  As such I can't get the tests to run.   I only have so much time.

I've have tested that the boolean functionally works with something like this:

```python
import onpy
document = onpy.get_document('<docno>')
partstudio = document.get_partstudio()
part1 = partstudio.parts.get('triangle')
part2 = partstudio.parts.get('Part 2')
partstudio.add_boolean_union(name="My perfect union",parts=[part1,part2],keep_tools=False)
```
Before:
<img width="330" alt="image" src="https://github.com/user-attachments/assets/1c3763f8-20a2-4b35-b0dc-4ee6426b00e2" />

After:
<img width="330" alt="image" src="https://github.com/user-attachments/assets/d3944036-82b8-4b9b-92df-5891ab0d2a81" />

